### PR TITLE
docs: expand README with live demo + screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,140 @@
-![alt text](project_screenshot/image.png)
-
-<h1 align="center">Programming Contest Tracker</h1>
-<h3 align="center">Tracks the performances of AUST's Team in various Programming Contest. </h3>
-
 <div align="center">
-  <a href="https://wakatime.com/badge/github/piru72/PC_TRACKER">
-    <img src="https://wakatime.com/badge/github/piru72/PC_TRACKER.svg" alt="wakatime">
-  </a>
+
+# 🏆 PC Tracker
+
+### Tracks the performances of AUST's team across various Programming Contests.
+
+**[🚀 Live Demo →](https://aust-pc-tracker.vercel.app)**
+
+<br/>
+
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=white)](https://react.dev/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Vite](https://img.shields.io/badge/Vite-4-646CFF?logo=vite&logoColor=white)](https://vitejs.dev/)
+[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
+[![wakatime](https://wakatime.com/badge/github/piru72/PC_TRACKER.svg)](https://wakatime.com/badge/github/piru72/PC_TRACKER)
+
 </div>
 
-# Installation
+---
 
-To run the project locally, the following steps can be followed:
+## 📸 Screenshots
 
-### Using npm
+### Summary of the contests
 
-```pwsh
-git clone https://github.com/piru72/pc-tracker.git
+![Summary of the contests](project_screenshot/image.png)
+
+### Contest details for downloading
+
+![Contest details for downloading](project_screenshot/image-1.png)
+
+### List of contestants
+
+![List of contestants](project_screenshot/image-2.png)
+
+### Contestant details
+
+![Contestant details](project_screenshot/image-3.png)
+
+---
+
+## ✨ Features
+
+- **Contest summary** — at-a-glance view of the contests AUST teams have participated in.
+- **Downloadable contest details** — export contest standings as image/data for sharing.
+- **Contestant list** — browse every team and contestant.
+- **Contestant details** — drill into an individual team's or contestant's performance.
+- **Scraper toolkit** — Python scrapers (`Scrapper/`) that pull standings from platforms such as [Toph](https://toph.co/) into structured JSON.
+
+---
+
+## 🚀 Tech Stack
+
+| Layer        | Technology                                                                 |
+| ------------ | -------------------------------------------------------------------------- |
+| Language     | TypeScript 5                                                               |
+| Framework    | React 18                                                                   |
+| Build tool   | Vite 4 (`@vitejs/plugin-react-swc`)                                         |
+| UI           | Chakra UI, Emotion, Framer Motion                                          |
+| Routing      | React Router DOM                                                           |
+| Data         | PapaParse / SheetJS (`xlsx`) — CSV-driven, fetched from `VITE_REACT_APP_CSV_URL` |
+| Export       | `html-to-image`, `html2canvas`, `file-saver`, `downloadjs`                 |
+| Markdown     | `react-markdown` + `remark-gfm`                                            |
+| Scrapers     | Python (`pandas`) under `Scrapper/`                                        |
+| Container    | Docker (multi-stage build → Nginx)                                         |
+| Hosting      | Vercel                                                                     |
+
+---
+
+## 📦 Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (LTS recommended) and npm
+- Optionally, [Docker](https://www.docker.com/) for the containerized workflow
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/parvez-ahammed/pc-tracker.git
 cd pc-tracker
-npm install
-npm run dev
 ```
 
-### Using Docker
+### 2. Configure environment variables
 
-```pwsh
-git clone https://github.com/piru72/pc-tracker.git
+Copy `example.env` to `.env` and point it at your contest data CSV:
 
-cd pc-tracker
+```bash
+cp example.env .env
+```
+
+```env
+VITE_REACT_APP_CSV_URL=<url-to-your-contest-data-csv>
+```
+
+### 3. Run locally with npm
+
+```bash
+npm install
+npm run dev      # start the Vite dev server
+```
+
+Other available scripts (from `package.json`):
+
+| Script            | Description                          |
+| ----------------- | ------------------------------------ |
+| `npm run dev`     | Start the Vite dev server            |
+| `npm run build`   | Type-check (`tsc`) and build for production |
+| `npm run preview` | Preview the production build locally |
+| `npm run lint`    | Run ESLint                           |
+
+### 4. Run with Docker
+
+```bash
 docker compose up -d
 ```
 
-# Key Features
+The app is then served at [http://localhost:8080](http://localhost:8080) (mapped from the container's Nginx on port 80).
 
-The following key features are available in the project:
+---
 
-- Summary of the contests.
-- Details of the contests for downloading.
-- List of contestants.
-- Details of the contestants.
+## 🤝 Contributing
 
-# License
+Contributions are welcome! Please read **[CONTRIBUTING.md](CONTRIBUTING.md)** for guidelines on adding features and new contests. Also see our **[Code of Conduct](CODE_OF_CONDUCT.md)** and **[Security Policy](SECURITY.md)**.
 
-This project is licensed under the GNU Affero General Public License v3.0. See the [LICENSE](LICENSE) file for details.
+---
 
-# Contributing
+## 🙏 Acknowledgements
 
-We welcome contributions from the community! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.
+Thanks to the AUST programming teams for their hard work and dedication, and to [Vercel](https://vercel.com/) for hosting the project.
 
-# Acknowledgements
+---
 
-We would like to thank the AUST programming teams for their hard work and dedication. Special thanks to Vercel for hosting the project.
+## 📄 License
 
-# Screenshots
+This project is licensed under the **GNU Affero General Public License v3.0**. See the [LICENSE](LICENSE) file for details.
 
-## Summary of the contests
-
-![alt text](project_screenshot/image.png)
-
-## The details of the contests for downloading
-
-![alt text](project_screenshot/image-1.png)
-
-## The list of contestants
-
-![alt text](project_screenshot/image-2.png)
-
-## The details of the contestants
-
-![alt text](project_screenshot/image-3.png)
+© 2026 Parvez Ahammed


### PR DESCRIPTION
## What

Expands the thin (~1.6 KB) README into a complete open-source landing page while keeping all existing accurate content.

- Centered `# 🏆 PC Tracker` header + tagline
- Prominent **[Live Demo](https://aust-pc-tracker.vercel.app)** link at the top
- Badges: License (AGPL-3.0), React, TypeScript, Vite, Docker, PRs welcome (plus the existing wakatime badge)
- `## 📸 Screenshots` — embeds the four images already in `project_screenshot/`
- `## ✨ Features` — contest summary, downloadable details, contestant list/details, scraper toolkit
- `## 🚀 Tech Stack` — table derived from `package.json` (React 18, TypeScript 5, Vite 4, Chakra UI, etc.)
- `## 📦 Getting Started` — real npm scripts (`dev`/`build`/`preview`/`lint`), the `VITE_REACT_APP_CSV_URL` env var from `example.env`, and the `docker compose up -d` flow from `docker-compose.yml` (port 8080)
- `## 🤝 Contributing` — links existing `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
- `## 📄 License` — AGPL-3.0 © 2026 Parvez Ahammed

## Why

Lower the barrier for new contributors and visitors: surface the live demo, show what the project does at a glance, and document the real setup steps.

## Safety

- **Additive only** — only `README.md` was changed. No source, config, or build files touched.
- **No CI workflow added** (explicitly out of scope).
- **LICENSE untouched** (already AGPL-3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)